### PR TITLE
Add default CODEOWNERS file for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Documentation and documentation-related files
+docs/* @ROCm/rocm-documentation
+*.md @ROCm/rocm-documentation
+*.rst @ROCm/rocm-documentation
+library/include/* @ROCm/rocm-documentation


### PR DESCRIPTION
To have our technical writers be flagged whenever a documentation change needs to be reviewed.