### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Motivation
+
+<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
+
+## Technical Details
+
+<!-- Explain the changes along with any relevant GitHub links. -->
+
+## Test Plan
+
+<!-- Explain any relevant testing done to verify this PR. -->
+
+## Test Result
+
+<!-- Briefly summarize test outcomes. -->
+
+## Submission Checklist
+
+- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


### PR DESCRIPTION
Standardize PR template across ROCm org.

Individual repos can override the default template by adding their own `.github/pull_request_template.md`.